### PR TITLE
Openapi endpoint implementation

### DIFF
--- a/.mia-template/README.md
+++ b/.mia-template/README.md
@@ -67,6 +67,7 @@ The following routes are exposed
 - [http://localhost:3000/hello]() - hello controller
 - [http://localhost:3000/-/ready]() - the service is ready (used by k8s)
 - [http://localhost:3000/-/healthz]() - the service is healthy (used by k8s)
+- [http://localhost:3000/documentation/json]() - the Open API 3 specification: default schema is in yaml, a client can specify Accept: as either application/vnd.oai.openapi+json or application/json to request JSON.
 
 ### Tag new project version
 

--- a/.mia-template/README.md
+++ b/.mia-template/README.md
@@ -69,6 +69,7 @@ The following routes are exposed
 - [http://localhost:3000/-/healthz]() - the service is healthy (used by k8s)
 - [http://localhost:3000/documentation/json]() - the Open API 3 specification: default schema is in yaml, a client can specify Accept: as either application/vnd.oai.openapi+json or application/json to request JSON.
 
+The Open API documentation exposed by the service can be statically expanded by modifying the configuration file `META-INF/openapi.yml`. 
 ### Tag new project version
 
 Please use the `tag.sh` to update the `pom.xml` project version and commit release to git.

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.openapi</groupId>
+            <artifactId>helidon-openapi</artifactId>
+            <version>2.2.2</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/eu/miaplatform/helidonHelloWorld/HelloWorldService.java
+++ b/src/main/java/eu/miaplatform/helidonHelloWorld/HelloWorldService.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 import javax.json.Json;
 import javax.json.JsonObject;
 
+import eu.miaplatform.helidonHelloWorld.helpers.LoggerFormatter;
 import io.helidon.config.Config;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.ServerRequest;

--- a/src/main/java/eu/miaplatform/helidonHelloWorld/Main.java
+++ b/src/main/java/eu/miaplatform/helidonHelloWorld/Main.java
@@ -21,12 +21,14 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import eu.miaplatform.helidonHelloWorld.helpers.LoggerFormatter;
 import io.helidon.common.LogConfig;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
 import io.helidon.media.jsonp.JsonpSupport;
 import io.helidon.metrics.MetricsSupport;
+import io.helidon.openapi.OpenAPISupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
 
@@ -114,11 +116,17 @@ public final class Main {
                         .webContext("/-/ready")
                         .build();
 
+                OpenAPISupport openapi = OpenAPISupport.builder()
+                        .config(config)
+                        .webContext("/documentation/json")
+                        .build();
+
                 return Routing.builder()
                         .register(health)                   // Health at "/-/healthz"
                         .register(metrics)                  // Metrics at "/-/metrics"
                         .register(readiness)                // Readiness at "/-/ready"
                         .register("/hello", helloWorldService)
+                        .register(openapi)                  // Readiness at "/documentation/json"
                         .build();
         }
 }

--- a/src/main/java/eu/miaplatform/helidonHelloWorld/Main.java
+++ b/src/main/java/eu/miaplatform/helidonHelloWorld/Main.java
@@ -126,7 +126,7 @@ public final class Main {
                         .register(metrics)                  // Metrics at "/-/metrics"
                         .register(readiness)                // Readiness at "/-/ready"
                         .register("/hello", helloWorldService)
-                        .register(openapi)                  // Readiness at "/documentation/json"
+                        .register(openapi)                  // Openapi documentation at "/documentation/json"
                         .build();
         }
 }

--- a/src/main/java/eu/miaplatform/helidonHelloWorld/helpers/LoggerFormatter.java
+++ b/src/main/java/eu/miaplatform/helidonHelloWorld/helpers/LoggerFormatter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package eu.miaplatform.helidonHelloWorld;
+package eu.miaplatform.helidonHelloWorld.helpers;
 
 import java.util.logging.Formatter;
 import java.util.logging.Level;

--- a/src/main/resources/META-INF/openapi.yml
+++ b/src/main/resources/META-INF/openapi.yml
@@ -1,0 +1,89 @@
+paths:
+  /hello:
+    get:
+      summary: Returns a generic greeting
+      description: Greeting to the user
+      parameters:
+        - in: path
+          description: Name to be greeted
+          name: name
+          schema:
+            type: string
+          required: false
+      responses:
+        200: 
+          description: Simple JSON containing the greeting
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/GreetingMessage'
+  /-/healthz:
+    get:
+      summary: Health Kubernetes probe route
+      responses:
+        200: 
+          description: OK
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/HealthResponse'
+  /-/ready:
+    get:
+      summary: Readiness Kubernetes probe route
+      responses:
+        200: 
+          description: OK
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/HealthResponse'
+
+components:
+  schemas: 
+    GreetingMessage:
+      type: object
+      properties: 
+        message: 
+          type: string
+    HealthResponse:
+      type: object
+      properties:
+        outcome:
+          type: string
+        status:
+          type: string
+        checks:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              state:
+                type: string
+              status:
+                type: string
+              data:
+                type: object
+                properties:
+                  free:
+                    type: string
+                  freeBytes:
+                    type: integer
+                  max:
+                    type: string
+                  maxBytes:
+                    type: integer
+                  percentFree:
+                    type: string
+                  total:
+                    type: string
+                  totalBytes:
+                    type: integer
+            required:
+              - name
+              - state
+              - status
+
+
+


### PR DESCRIPTION
Openapi endpoint at `/documentation/json`. By default it returns a yaml schema. To request JSON, the client must add the `Accept` header: as either `application/vnd.oai.openapi+json` or `application/json`.