### PR TITLE
Added resources consumption and performance report

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,23 @@ By running autocannon on the `/hello` route, we obtain the following performance
 Running 10s test @ http://localhost:3000/hello
 10 connections
 
-| |Stat|2.5%|50%|97.5%|99%|Avg|Stdev|Max|
-|-|----|----|---|-----|---|---|-----|---|
-|Non-native image|Latency|51 [ms]|95 [ms]|379 [ms]|543 [ms]|109.82 [ms]|87.04 [ms]|823 [ms]|
-|Native image|Latency|47 [ms]|57 [ms]|71 [ms]|94 [ms]|58.12 [ms]|11.61 [ms]|214 [ms]|
+|Stat|Image|2.5%|50%|97.5%|99%|Avg|Stdev|Max|
+|----|-----|----|---|-----|---|---|-----|---|
+|Latency|Non-native|51 [ms]|95 [ms]|379 [ms]|543 [ms]|109.82 [ms]|87.04 [ms]|823 [ms]|
+| |Native|47 [ms]|57 [ms]|71 [ms]|94 [ms]|<span style="color:green">58.12 [ms]</span>|11.61 [ms]|214 [ms]|
 <br />
 
-| |Stat|1%|2.5%|50%|97.5%|Avg|Stdev|Min|
-|-|----|--|----|---|-----|---|-----|---|
-|Non-native image|Req/Sec|24|24|100|133|90.4|32.76|24|
-| |Bytes/Sec|3.79 [kB]|3.79 [kB]|15.8 [kB]|21 [kB]|14.3 [kB]|5.18 [kB]|3.79 [kB]|
-|Native image|Req/Sec|151|151|172|175|170.2|6.73|151|
-| |Bytes/Sec|23.9 [kB]|23.9 [kB]|27.2 [kB]|27.7 [kB]|26.9 [kB]|1.06 [kB]|23.9 [kB]|
+|Stat|Image|1%|2.5%|50%|97.5%|Avg|Stdev|Min|
+|----|-----|--|----|---|-----|---|-----|---|
+|Req/Sec|Non-native|24|24|100|133|90.4|32.76|24|
+| |Native|151|151|172|175|<span style="color:green">170.2</span>|6.73|151|
+|Bytes/Sec|Non-native|3.79 [kB]|3.79 [kB]|15.8 [kB]|21 [kB]|14.3 [kB]|5.18 [kB]|3.79 [kB]|
+| |Native|23.9 [kB]|23.9 [kB]|27.2 [kB]|27.7 [kB]|<span style="color:green">26.9 [kB]</span>|1.06 [kB]|23.9 [kB]|
 <br />
 
 Non-native image: 904 requests in 10.05s, 143 kB read
 <br />
-Native image: 2k requests in 10.03s, 269 kB read
+Native image: <span style="color:green">2k requests</span> in 10.03s, 269 kB read
 
 with the following consumption of resources:
 | |CPU|Memory|
@@ -52,7 +52,7 @@ with the following consumption of resources:
 |Native|5 [mCPU]|32 [Mi]|
 <br />
 
-Therefore, the native image attends about twice the number of requests while consuming much less memory and cpu.
+Therefore, the native image attends about twice the number of requests while consuming much less memory and cpu and having lower latency.
 
 ## Expose an endpoint to your microservice
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ A more detailed description on how to create a Microservice can be found in [Mic
 > * Memory: minimum **100Mi**, maximum **300Mi**
 > * CPU: minimum **10m**, maximum **500m**
 
+### Resources and Performance
+By running autocannon on the `/hello` route, we obtain the following performance: 
+
+> autocannon http://localhost:3000/hello
+Running 10s test @ http://localhost:3000/hello
+10 connections
+
+| |Stat|2.5%|50%|97.5%|99%|Avg|Stdev|Max|
+|-|----|----|---|-----|---|---|-----|---|
+|Non-native image|Latency|51 [ms]|95 [ms]|379 [ms]|543 [ms]|109.82 [ms]|87.04 [ms]|823 [ms]|
+|Native image|Latency|47 [ms]|57 [ms]|71 [ms]|94 [ms]|58.12 [ms]|11.61 [ms]|214 [ms]|
+<br />
+
+| |Stat|1%|2.5%|50%|97.5%|Avg|Stdev|Min|
+|-|----|--|----|---|-----|---|-----|---|
+|Non-native image|Req/Sec|24|24|100|133|90.4|32.76|24|
+| |Bytes/Sec|3.79 [kB]|3.79 [kB]|15.8 [kB]|21 [kB]|14.3 [kB]|5.18 [kB]|3.79 [kB]|
+|Native image|Req/Sec|151|151|172|175|170.2|6.73|151|
+| |Bytes/Sec|23.9 [kB]|23.9 [kB]|27.2 [kB]|27.7 [kB]|26.9 [kB]|1.06 [kB]|23.9 [kB]|
+<br />
+
+Non-native image: 904 requests in 10.05s, 143 kB read
+<br />
+Native image: 2k requests in 10.03s, 269 kB read
+
+with the following consumption of resources:
+| |CPU|Memory|
+|-|---|------|
+|Non-native|66 [mCPU]|75 [Mi]|
+|Native|5 [mCPU]|32 [Mi]|
+<br />
+
+Therefore, the native image attends about twice the number of requests while consuming much less memory and cpu.
 
 ## Expose an endpoint to your microservice
 


### PR DESCRIPTION
Added a performance report to documentation
- to compare native and non-native image performances,
- to monitor resources consumption (cpu and memory)